### PR TITLE
(MODULES-6598) remove semantic_puppet dependency

### DIFF
--- a/puppet_pot_generator.gemspec
+++ b/puppet_pot_generator.gemspec
@@ -22,13 +22,12 @@ Gem::Specification.new do |spec|
   spec.summary = 'Generates a pot file from your puppet code'
 
   spec.add_runtime_dependency 'puppet'
-  spec.add_runtime_dependency 'semantic_puppet'
 
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec-its', '~> 1.0'
-  spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
+  spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'pry'
 end


### PR DESCRIPTION
Puppet 5.3.4 does some new i18n-fu and takes matters into its own hands when handling text_domains and so on, breaking the dependency on ye olde gettext-setup gem. semantic_puppet still uses the gettext-setup gem and when it tries to switch the text_domain to "master_domain", it does not exist. puppet_pot_generator depends on semantic_puppet, so the gem presumably pulls that dependency in and  things try to use it instead of the vendored semantic_puppet. Also, Puppet > 4.9.0 does not require semantic_puppet any longer, so we are killing it with fire. Here, anyway.