### PR TITLE
(maint) Pin Rubocop version to '< 0.53'

### DIFF
--- a/puppet_pot_generator.gemspec
+++ b/puppet_pot_generator.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '< 0.53'
   spec.add_development_dependency 'rubocop-rspec'
 end


### PR DESCRIPTION
CI test failures were being caused by the deprecated cop 'Style/TrailingCommaInLiteral' being used. Options were to remove the cop or use Rubocop version < 0.53, before they split up the
cop in to many more versions.

See advice given in [this pdk-templates PR](https://github.com/puppetlabs/pdk-templates/issues/242)